### PR TITLE
require openseadragon if it doesn't exist

### DIFF
--- a/openseadragon-canvas-overlay.js
+++ b/openseadragon-canvas-overlay.js
@@ -1,15 +1,18 @@
 // OpenSeadragon canvas Overlay plugin 0.0.2 based on svg overlay plugin
 
 (function() {
-
-    if (!window.OpenSeadragon) {
-        console.error('[openseadragon-canvas-overlay] requires OpenSeadragon');
-        return;
+    
+    $ = window.OpenSeadragon;
+    
+    if (!$) {
+        $ = require('openseadragon');
+        if (!$) {
+            throw new Error('OpenSeadragon is missing.');
+        }
     }
 
-
     // ----------
-    OpenSeadragon.Viewer.prototype.canvasOverlay = function(options) {
+    $.Viewer.prototype.canvasOverlay = function(options) {
         
         if (this._canvasOverlayInfo) {
             return this._canvasOverlayInfo;
@@ -84,7 +87,7 @@
                 this._canvasdiv.setAttribute('height', this._containerHeight);
                 this._canvas.setAttribute('height', this._containerHeight);
             }
-            this._viewportOrigin = new OpenSeadragon.Point(0, 0);
+            this._viewportOrigin = new $.Point(0, 0);
             var boundsRect = this._viewer.viewport.getBounds(true);
             this._viewportOrigin.x = boundsRect.x;
             this._viewportOrigin.y = boundsRect.y * this.imgAspectRatio;


### PR DESCRIPTION
require openseadragon if it doesn't exist

Fixes the `[openseadragon-canvas-overlay] requires OpenSeadragon` error when doing this:

```
import OpenSeadragon from 'openseadragon';
import 'svg-overlay';
```

Borrowed style from https://github.com/usnistgov/OpenSeadragonFiltering/blob/master/openseadragon-filtering.js

setting OpenSeadragon object to `$`

Note, I requested a similar change in svg-overlay:
https://github.com/openseadragon/svg-overlay/commit/e7bfc6725b15ff5cfa7788f01a877964e9480baf#diff-d723f0aa2fac0a96816f277e6c2b17e2